### PR TITLE
スプライトクラスを追加

### DIFF
--- a/Ennichi.vcxproj
+++ b/Ennichi.vcxproj
@@ -91,7 +91,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)/3.22c_VS;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -116,8 +116,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir)/3.22c_VS;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>main.h</PrecompiledHeaderFile>
+      <PrecompiledHeader>Create</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -139,7 +139,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)/3.22c_VS;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -164,8 +164,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir)/3.22c_VS;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>main.h</PrecompiledHeaderFile>
+      <PrecompiledHeader>Create</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Ennichi.vcxproj
+++ b/Ennichi.vcxproj
@@ -197,7 +197,9 @@
     <ClInclude Include="KeyInput.h" />
     <ClInclude Include="main.h" />
     <ClInclude Include="Obj.h" />
+    <ClInclude Include="ObjGroup.h" />
     <ClInclude Include="Poi.h" />
+    <ClInclude Include="Sprite.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="StringObj.h" />
     <ClInclude Include="Timer.h" />

--- a/Ennichi.vcxproj.filters
+++ b/Ennichi.vcxproj.filters
@@ -54,6 +54,12 @@
     <ClInclude Include="main.h">
       <Filter>ヘッダーファイル\特別なヘッダ</Filter>
     </ClInclude>
+    <ClInclude Include="ObjGroup.h">
+      <Filter>ヘッダーファイル\オブジェクトクラス</Filter>
+    </ClInclude>
+    <ClInclude Include="Sprite.h">
+      <Filter>ヘッダーファイル\その他のヘッダ</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="ソースファイル">
@@ -70,6 +76,9 @@
     </Filter>
     <Filter Include="ヘッダーファイル\汎用クラス">
       <UniqueIdentifier>{35ded6b3-9026-479a-884b-73a42daaea9f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ヘッダーファイル\その他のヘッダ">
+      <UniqueIdentifier>{f63404b4-d136-48c0-a2d1-039129e77737}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/Goldfish.h
+++ b/Goldfish.h
@@ -53,7 +53,7 @@ public:
 
 	//次のフレームに更新(検討中)
 	//金魚が向いてる向きに(x,y)を進める
-	inline void Next()
+	inline void next()
 	{
 		double delx = speed * std::cos(angle + ANGLE0) + xerr;
 		double dely = speed * std::sin(angle + ANGLE0) + yerr;
@@ -100,8 +100,8 @@ public:
 		int x,
 		int	y,
 		bool can_collision,
-		const std::vector<const char*>& image_path
-	) : Obj(x,y,can_collision,image_path)
+		const Sprite& sprite0
+	) : Obj(x,y,can_collision,sprite0)
 	{}
 
 	//コンストラクタ(検討中)
@@ -110,8 +110,8 @@ public:
 		int	y,
 		double angle,
 		bool can_collision,
-		const std::vector<const char*>& image_path
-	) : Obj(x,y,angle,can_collision,image_path)
+		const Sprite& sprite0
+	) : Obj(x,y,angle,can_collision,sprite0)
 	{}
 
 

--- a/Obj.h
+++ b/Obj.h
@@ -1,21 +1,20 @@
 #pragma once
 #include "stdafx.h"
-
+#include "Sprite.h"
 
 class Obj
 {
 public:
 	/* メンバ変数 */
 	int x, y; // オブジェクトの座標
-	int xlength=0, ylength=0; // x, y方向の長さ
+	int xlength, ylength; // x, y方向の長さ
 	int state = 0; // 描画する画像の、imageにおける添え字
 
 	double angle = 0.0; // 画像の回転
 
 	bool can_collision; // 他のオブジェクトと衝突するかどうか
 
-	std::vector<int> images; // ロードした画像(ハンドル)のリスト
-
+	Sprite sprite;//スプライト
 
 	
 	/* メンバ関数 */
@@ -23,50 +22,37 @@ public:
 		int x,
 		int	y,
 		bool can_collision,
-		const std::vector<const char*>& image_path
-	) : x(x), y(y), can_collision(can_collision)
-	{
-		/* image_pathで指定された画像を読み込み, imagesに保存 */
-		for (int i = 0; i < (int)image_path.size(); i++) {
-			int t = LoadGraph(image_path[i]); // 指定画像を読み込む
-			if (t == -1) {
-				exit(1);
-			}
-			images.push_back(t); // imagesに追加
-			GetGraphSize(images[0], &xlength, &ylength);
-		}
-	}
+		const Sprite& sprite0
+	) : x(x), 
+		y(y), 
+		can_collision(can_collision), 
+		sprite(sprite0), 
+		xlength(sprite0.width), 
+		ylength(sprite0.height)
+	{}
+	
 
 	Obj( // コンストラクタ(角度指定あり)
 		int x,
 		int	y,
 		double angle,
 		bool can_collision,
-		const std::vector<const char*>& image_path
-	) : x(x), y(y), angle(angle), can_collision(can_collision)
-	{
-		/* image_pathで指定された画像を読み込み, imagesに保存 */
-		for (int i = 0; i < (int)image_path.size(); i++) {
-			int t = LoadGraph(image_path[i], 1); // 指定画像を読み込む
-			if (t == -1) {
-				exit(1);
-			}
-			images.push_back(t); // imagesに追加
-			GetGraphSize(images[0], &xlength, &ylength);
-		}
-	}
+		const Sprite& sprite0
+	) : x(x), 
+		y(y), 
+		angle(angle), 
+		can_collision(can_collision),
+		sprite(sprite0),
+		xlength(sprite0.width),
+		ylength(sprite0.height)
+	{}
 
 
-	virtual ~Obj() {
-		for (int i = 0; i < (int)images.size(); i++) {
-			DeleteGraph(images[i]); // 読み込んだ画像をメモリから削除
-		}
-	}
 
 	virtual void draw()
 	{
 		/* オブジェクトを画面に反映する */
-		if (DrawRotaGraph(x + xlength / 2, y + ylength / 2, 1.0, angle, images[state], 1) == -1) {
+		if (DrawRotaGraph(x + xlength / 2, y + ylength / 2, 1.0, angle, sprite[state], 1) == -1) {
 			throw new std::runtime_error("描画失敗");
 			exit(1);
 		}

--- a/ObjGroup.h
+++ b/ObjGroup.h
@@ -1,0 +1,18 @@
+﻿#pragma once
+
+class ObjGroup
+{
+private:
+	
+public:
+	ObjGroup()
+	{
+
+	}
+
+	template<class T>
+	void add(T obj)
+	{
+
+	}
+};

--- a/Poi.h
+++ b/Poi.h
@@ -5,7 +5,7 @@
 //ポイのクラスの定義(Objの継承)
 class Poi : public Obj {
 public:
-	Poi(int x, int	y, bool can_collision, const std::vector<const char*>& image_path) : Obj(x, y, can_collision, image_path) {};
+	Poi(int x, int	y, bool can_collision, const Sprite& sprite0) : Obj(x, y, can_collision, sprite0) {};
 	//Objの角度なしコンストラクタ呼び出し
 	//画像サイズが400×400の時のとき、左上に対する中心の座標は(240,160)
 	inline std::vector<int> center()const&

--- a/Sprite.h
+++ b/Sprite.h
@@ -26,7 +26,7 @@ public:
 		image_handle = new int[__length];
 		for (auto& path : image_path)
 		{
-			image_handle[i] = LoadGraph(path);
+			image_handle[i] = LoadGraph(path, 1);
 			++i;
 		}
 		GetGraphSize(image_handle[0], &width, &height);
@@ -40,7 +40,7 @@ public:
 		image_handle = new int[__length];
 		for (auto& path : path_list)
 		{
-			image_handle[i] = LoadGraph(path);
+			image_handle[i] = LoadGraph(path, 1);
 			++i;
 		}
 		GetGraphSize(image_handle[0], &width, &height);

--- a/Sprite.h
+++ b/Sprite.h
@@ -1,0 +1,107 @@
+﻿#pragma once
+
+class Sprite
+{
+private:
+	/* 外部アクセス不可 */
+	int __length;//コマ数
+	int* image_handle;//グラフィックのハンドル(動的配列)
+
+public:
+	/* アクセス可能 */
+	int width;//横幅
+	int height;//高さ
+
+	//デフォルトコンストラクタ
+	Sprite():__length{0},width{0},height{0}
+	{
+		image_handle = nullptr;
+	}
+
+	//コンストラクタ
+	Sprite(std::vector<const char*> image_path):__length{static_cast<int>(image_path.size())}
+	{
+		int i = 0;
+		image_handle = new int[__length];
+		for (auto& path : image_path)
+		{
+			image_handle[i] = LoadGraph(path);
+			++i;
+		}
+		GetGraphSize(image_handle[0], &width, &height);
+	}
+
+	//コンストラクタ
+	Sprite(std::initializer_list<const char*> path_list
+	) :__length{static_cast<int>(path_list.size())}
+	{
+		int i = 0;
+		image_handle = new int[__length];
+		for (auto& path : path_list)
+		{
+			image_handle[i] = LoadGraph(path);
+			++i;
+		}
+		GetGraphSize(image_handle[0], &width, &height);
+	}
+
+	//コピーコンストラクタ
+	Sprite(const Sprite& base):__length{base.__length}, width{base.width}, height{base.height}
+	{
+		if (__length == -1)
+			throw new std::invalid_argument("destroyしたオブジェクトはコピーできません");
+		image_handle = new int[__length];
+		for (int i = 0; i < __length; ++i)
+		{
+			image_handle[i] = base.image_handle[i];
+		}
+	}
+
+	//コピー代入演算子
+	Sprite& operator=(const Sprite& base)
+	{
+		if (base.__length == -1)
+			throw new std::invalid_argument("destroyしたオブジェクトはコピーできません");
+		__length = base.__length;
+		width = base.width;
+		height = base.height;
+		image_handle = new int[__length];
+		for (int i = 0; i < __length; ++i)
+		{
+			image_handle[i] = base.image_handle[i];
+		}
+	}
+
+	//ムーブコンストラクタを自動生成
+	Sprite(Sprite&&) = default;
+	Sprite& operator=(Sprite&&) = default;
+
+	//デストラクタ
+	virtual ~Sprite()
+	{
+		if(image_handle!=nullptr)
+			delete[] image_handle;
+	}
+
+	//添え字演算子
+	int operator[](int index)const&
+	{
+		if (index < 0 || index >= __length)
+			throw new std::out_of_range("インデックスが範囲外");
+		return image_handle[index];
+	}
+
+	//スプライトを完全に破棄
+	void destroy()
+	{
+		for (int i = 0; i < __length; ++i)
+		{
+			DeleteGraph(image_handle[i]);
+		}
+		__length = 0;
+		width = 0;
+		height = 0;
+		delete[] image_handle;
+		image_handle = nullptr;
+	}
+};

--- a/Sprite.h
+++ b/Sprite.h
@@ -19,7 +19,8 @@ public:
 	}
 
 	//コンストラクタ
-	Sprite(std::vector<const char*> image_path):__length{static_cast<int>(image_path.size())}
+	Sprite(const std::vector<const char*>& image_path
+	):__length{static_cast<int>(image_path.size())}
 	{
 		int i = 0;
 		image_handle = new int[__length];

--- a/game_temp.cpp
+++ b/game_temp.cpp
@@ -42,9 +42,9 @@
 			{
 				windowFlag = 1;
 			}
-			fish1.Next();
+			fish1.next();
 			fish2.SetMovement(MOV_OPTION::WAVE, 20.0, 300.0);
-			fish2.Next();
+			fish2.next();
 			first.point_change();
 
 			if (input.GetKeyDown(KEY_INPUT_Z) == 1 && fish2.isCought(first, mt, dice))printfDx("•ß‚Ü‚Á‚½");

--- a/game_temp.cpp
+++ b/game_temp.cpp
@@ -1,3 +1,4 @@
+#include "stdafx.h"
 #include "main.h"
  void game_temp() {
 

--- a/gun.h
+++ b/gun.h
@@ -4,8 +4,8 @@
 
 class Gun : public Obj {
 public:
-	Gun(int x, int	y, bool can_collision, const std::vector<const char*>& image_path) 
-		: Obj(x, y, can_collision, image_path) {};
+	Gun(int x, int	y, bool can_collision, const Sprite& sprite0) 
+		: Obj(x, y, can_collision, sprite0) {};
 	void gunnt_change() {
 		SetDrawScreen(DX_SCREEN_BACK);  // 表示画面を裏に
 		ClearDrawScreen();  // 画面全体をクリア

--- a/kingyomain.cpp
+++ b/kingyomain.cpp
@@ -1,4 +1,5 @@
-﻿#include "main.h"
+﻿#include "stdafx.h"
+#include "main.h"
 void kingyomain() {
 	int windowFlag = 0;  // 現在のウィンドウを管理するフラグ
 	int FramePerSecond = 60;//fps

--- a/kingyomain.cpp
+++ b/kingyomain.cpp
@@ -12,7 +12,7 @@ void kingyomain() {
 	std::mt19937_64 mt(seed());
 	std::uniform_int_distribution<> dice(1, 1000);
 
-	Sprite kingyo_spr(path);
+	Sprite kingyo_spr{ "./image/kingyo.png", "./image/background.png" };
 	Sprite button_spr(buttonpath);
 	Sprite poi_spr(poi_path);
 

--- a/kingyomain.cpp
+++ b/kingyomain.cpp
@@ -12,6 +12,10 @@ void kingyomain() {
 	std::mt19937_64 mt(seed());
 	std::uniform_int_distribution<> dice(1, 1000);
 
+	Sprite kingyo_spr(path);
+	Sprite button_spr(buttonpath);
+	Sprite poi_spr(poi_path);
+
 	int px, py;
 	int click_event, button_type, cx, cy, log_type;
 
@@ -19,9 +23,9 @@ void kingyomain() {
 	Button button2(250, 240 + 115 + 10, false, buttonpath);
 	Button button3(250, 240 + 115 * 2 + 10 * 2, false, buttonpath);
 
-	Goldfish *fish1=new Goldfish(0, 0, std::_Pi, true, path); //金魚
-	Goldfish fish2(100, 0, std::_Pi * 3.0 / 4.0, true, path);
-	Poi first(500, 500, true, poi_path);//ポイ
+	Goldfish* fish1 = new Goldfish(0, 0, std::_Pi, true, kingyo_spr); //金魚
+	Goldfish fish2(100, 0, std::_Pi * 3.0 / 4.0, true, kingyo_spr);
+	Poi first(500, 500, true, poi_spr);//ポイ
 	Goldfish fish3 = *fish1;
 
 	fish1->setDifficulty(50);
@@ -70,10 +74,10 @@ void kingyomain() {
 			input();
 			if (fish1 != NULL)
 			{
-				fish1->Next();
+				fish1->next();
 				fish1->draw();
 			}
-			fish3.Next();
+			fish3.next();
 			fish3.draw();;
 			first.point_change();
 			first.draw();
@@ -90,6 +94,9 @@ void kingyomain() {
 
 		}
 		else {  // ゲームの終了
+			kingyo_spr.destroy();
+			poi_spr.destroy();
+			button_spr.destroy();
 			return;
 		}
 		ScreenFlip();

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,4 @@
+#include "stdafx.h"
 #include "main.h"    
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {

--- a/main.h
+++ b/main.h
@@ -1,4 +1,5 @@
-﻿#include "stdafx.h"
+﻿#pragma once
+#include "stdafx.h"
 #include "Button.h"
 #include "functions.h"
 #include "Goldfish.h"

--- a/shooting.cpp
+++ b/shooting.cpp
@@ -1,3 +1,4 @@
+#include "stdafx.h"
 #include "main.h"
 
 void shootingmain() {

--- a/title.cpp
+++ b/title.cpp
@@ -1,4 +1,5 @@
-﻿#include "main.h"
+﻿#include "stdafx.h"
+#include "main.h"
 
 int FontHandle;
 void titlemain() {


### PR DESCRIPTION
# マージするかは検討中です
## 実装の概要
* Spriteクラス
   * メンバ変数
      * `int Sprite::__length;`コマ数
      * `int* Sprite::image_handle;`グラフィックハンドル
      * `int Sprite::width;`横幅
      * `int Sprite::height;`高さ
   * コンストラクタ `Sprite::Sprite(const std::vector<const char*>&);`
      * グラフィックハンドルを保存しておく
   * コンストラクタ `Sprite::Sprite(std::initializer_list<const char*>);`
      * グラフィックハンドルを保存しておく
      * `Sprite sprite{"./image/kingyo.png", "./image/background.png"};`
        という感じで実行する
   * 添え字演算子 `int Sprite::operator[](int)const&` 
      * グラフィックハンドルを取得する
      * 書き込みはできない
   * メンバ関数 `void Sprite::destroy()`
      * スプライトを完全に破棄する
      * そのスプライトを使わなくなったときに実行
   * その他の関数(勝手に使われる)
      * コピーコンストラクタ `Sprite::Sprite(const Sprite&);`
      * コピー代入演算子 `Sprite& Sprite::operator=(const Sprite&);`
      * ムーブコンストラクタ `Sprite::Sprite(Sprite&&);`
      * ムーブ代入演算子 `Sprite& Sprite::operator=(Sprite&&);`
      * デストラクタ `virtual Sprite::~Sprite();`
## 見てほしいところ
* コンストラクタ
* 添え字演算子
## 既知のバグ