### PR TITLE
ポイによる金魚の捕獲を実装

### DIFF
--- a/Poi.h
+++ b/Poi.h
@@ -7,10 +7,10 @@ class Poi : public Obj {
 public:
 	Poi(int x, int	y, bool can_collision, const std::vector<int>& image_handle) : Obj(x, y, can_collision, image_handle) {};
 	//Objの角度なしコンストラクタ呼び出し
-	//画像サイズが400×400の時のとき、左上に対する中心の座標は(240,160)
+	//画像サイズが128x128の時のとき、左上に対する中心の座標は(62, 48)
 	inline std::vector<int> center()const&
 	{
-		std::vector<int> pos = {x + 58, y + 34};
+		std::vector<int> pos = {x + 62, y + 48};
 		return pos;
 	}
 


### PR DESCRIPTION
# 実装の概要
* zキーで金魚が捕獲できるようになりました
* 金魚が2点、出目金が3点のスコアの重みづけを実装しました
# 見てほしいところ
* 正しく捕獲とスコア計算がされているか
* 捕獲周りの操作でエラーが起こるか
# 既知のバグ
* ゲーム終了時に「hoge匹捕まえたよ」との表示があるが、スコアが表示されている