### PR TITLE
金魚の当たり判定の部分を大幅修正

### DIFF
--- a/Aim.h
+++ b/Aim.h
@@ -4,7 +4,6 @@
 
 class Aim : public Poi {
 public:
-	double scale = 1.0;
 	Aim(int x,
 		int	y,
 		bool can_collision,

--- a/Ennichi.vcxproj.filters
+++ b/Ennichi.vcxproj.filters
@@ -61,7 +61,7 @@
       <Filter>ヘッダーファイル\オブジェクトクラス</Filter>
     </ClInclude>
     <ClInclude Include="Aim.h">
-      <Filter>ソースファイル</Filter>
+      <Filter>ヘッダーファイル\オブジェクトクラス</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Obj.h
+++ b/Obj.h
@@ -7,6 +7,7 @@ class Obj
 protected:
 	/* 派生クラスのみアクセス可能 */
 	unsigned int __frames = 0;
+	double scale = 1.0; // 画像の表示倍率
 
 public:
 	/* メンバ変数 */
@@ -19,6 +20,7 @@ public:
 
 	int xlength=0, ylength=0; // x, y方向の長さ
 	int state = 0; // 描画する画像の、imageにおける添え字
+
 	/* メンバ関数 */
 	Obj( // コンストラクタ
 		int x,
@@ -63,10 +65,17 @@ public:
 
 	}
 
+	void setScale(double scale0)
+	{
+		scale = scale0;
+		xlength = (int)(xlength * scale);
+		ylength = (int)(ylength * scale);
+	}
+
 	virtual void draw()
 	{
 		/* オブジェクトを画面に反映する */
-		if (DrawRotaGraph(x + xlength / 2, y + ylength / 2, 1.0, angle, images[state], 1) == -1) {
+		if (DrawRotaGraph(x + xlength / 2, y + ylength / 2, scale, angle, images[state], 1) == -1) {
 			throw new std::runtime_error("描画失敗");
 			exit(1);
 		}
@@ -153,6 +162,11 @@ public:
 		{
 			tmp.Next();
 		}
+	}
+
+	unsigned int size()noexcept
+	{
+		return (unsigned int)(objects.size());
 	}
 
 	void destroy(std::size_t index)

--- a/kingyomain.cpp
+++ b/kingyomain.cpp
@@ -103,6 +103,7 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 					if (i % 2 == 0) telescope_group[i].SetMovement(MOV_OPTION::CIRCLE, 300, 1.0);
 					if (i % 3 == 0) telescope_group[i].SetMovement(MOV_OPTION::WAVE, 100, 100);
 				}
+				poi_num_remaining = 5;
 				for (unsigned char i = 0; i < poi_num_remaining; ++i)
 				{
 					/* 残りポイ数表示用オブジェクトグループ */

--- a/kingyomain.cpp
+++ b/kingyomain.cpp
@@ -62,6 +62,11 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 	/* ゲーム開始前の初期化処理 */
 	if (calling_check == 0) PlaySoundMem(bgm, DX_PLAYTYPE_LOOP); // bgmを読み込む
 
+	for (unsigned char i = 0; i < poi_num_remaining; ++i)
+	{
+		/* 残りポイ数表示用オブジェクトグループ */
+		remaining_poi[i].x -= 40 * i; // ポイの位置をずらす
+	}
 
 	/* ゲームループ */
 	while (1) {
@@ -104,11 +109,7 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 					if (i % 3 == 0) telescope_group[i].SetMovement(MOV_OPTION::WAVE, 100, 100);
 				}
 				poi_num_remaining = 5;
-				for (unsigned char i = 0; i < poi_num_remaining; ++i)
-				{
-					/* 残りポイ数表示用オブジェクトグループ */
-					remaining_poi[i].x -= 40 * i; // ポイの位置をずらす
-				}
+
 
 				timer60sec.reset();
 				cought_kingyo = 0;

--- a/kingyomain.cpp
+++ b/kingyomain.cpp
@@ -136,7 +136,7 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 				/* zキーが押された */
 				poi_destroy = true;
 				for (int i = 0; i < (int)kingyo_group.size(); i++) {
-					if (kingyo_group[i].isCought(poi, mt, dice)) {
+					if (kingyo_group[i].isCought(poi)) {
 						switch (rand_four(mt))
 						{
 						case 0:
@@ -159,7 +159,7 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 					}
 				}
 				for (int i = 0; i < (int)telescope_group.size(); i++) {
-					if (telescope_group[i].isCought(poi, mt, dice)) {
+					if (telescope_group[i].isCought(poi)) {
 						switch (rand_four(mt))
 						{
 						case 0:

--- a/kingyomain.cpp
+++ b/kingyomain.cpp
@@ -13,6 +13,9 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 	std::random_device seed; // 乱数生成器
 	std::mt19937_64 mt(seed());
 	std::uniform_int_distribution<> dice(1, 1000);
+	std::uniform_int_distribution<> rand_four(0, 3);//0~3を返す乱数
+	std::uniform_int_distribution<> rand_posx(101, 1080);//x座標を決める乱数
+	std::uniform_int_distribution<> rand_posy(101, 500);//y座標を決める乱数
 	int px, py; // マウスポインタの座標
 	int click_event, button_type, cx, cy, log_type;	// マウスポインタのイベント管理用変数
 	KeyInput z_push(KEY_INPUT_Z); // zキーが押されたかどうかを管理する変数
@@ -20,6 +23,8 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 	Timer timer80sec(2400); // 結果 -> タイトルまでに使うタイマー
 	size_t kingyo_num = 5; // 金魚の数
 	size_t telescope_num = 100; //出目金の数
+	unsigned char poi_num_remaining = 5;// 残りポイの数
+	bool poi_destroy; // ポイが破れるフラグ
 	int kingyo_score = 2; // 金魚一匹捕まえたときのスコア
 	int telescope_score = 3; // 出目金一匹捕まえたときのスコア
 	const std::string buff1 = "金魚すくい! あなたは";
@@ -41,34 +46,22 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 	makeImageHandle(poi_handle, "./asset/image/poi.png", "./asset/image/Telescope.png");
 	Goldfish kingyo(500, 500, pi/2,true, kingyo_handle); // コピー元金魚
 	Goldfish telescope(500, 400, true, telescope_handle); // コピー元出目金
+	Obj poiFake(1200, 10, false, poi_handle);// 当たり判定の無いポイ
+	poiFake.setScale(0.25);
 
 	Button button_start(400, 300, button_handle); // 金魚掬いのSTARTボタン
 	Button button_back(520, 400, button_back_handle); // 戻るボタン
 	Poi poi(100, 100, true, poi_handle); // ポイ
 	ObjGroup<Goldfish> kingyo_group; // 金魚のグループ
 	ObjGroup<Goldfish> telescope_group; // 出目金のグループ
+	ObjGroup<Obj> remaining_poi; //ポイの残り個数表示
 	kingyo_group.addcpy(kingyo, (unsigned int)kingyo_num); // グループ初期化
 	telescope_group.addcpy(telescope, (unsigned int)telescope_num);
+	remaining_poi.addcpy(poiFake, (unsigned int)poi_num_remaining);
 
 	/* ゲーム開始前の初期化処理 */
 	if (calling_check == 0) PlaySoundMem(bgm, DX_PLAYTYPE_LOOP); // bgmを読み込む
-	for (unsigned int i = 0; i < kingyo_num; i++) {
-		/* 金魚グループに関する初期化 */
-		kingyo_group[i].setSpeed(1.0, 3.0); // 金魚のスピードを設定
-		kingyo_group[i].setDifficulty(1);
-		kingyo_group[i].animsp = 30; // アニメーションの設定
-		kingyo_group[i].spawn_position(dice(mt)%980 +100, dice(mt)%400 + 100);//範囲内に収まるように補正
-		if (i % 2 == 0) kingyo_group[i].SetMovement(MOV_OPTION::CIRCLE, 300, 1.0);
-		if (i % 3 == 0)kingyo_group[i].SetMovement(MOV_OPTION::WAVE, 100, 100);
-	}
-	for (unsigned int i = 0; i < telescope_num; i++) {
-		/* 出目金グループに関する初期化 */
-		telescope_group[i].setSpeed(1.0, 3.0); // 出目金のスピードを設定
-		telescope_group[i].setDifficulty(1);
-		telescope_group[i].animsp = 30; // アニメーションの設定
-		if (i %  2 == 0) telescope_group[i].SetMovement(MOV_OPTION::CIRCLE, 300, 1.0);
-		if (i %  3== 0) telescope_group[i].SetMovement(MOV_OPTION::WAVE, 100, 100);
-	}
+
 
 	/* ゲームループ */
 	while (1) {
@@ -92,6 +85,30 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 			if (button_start.isReleasedLeft(click_event, button_type, cx, cy, log_type)) {
 				PlaySoundMem(effect, DX_PLAYTYPE_BACK);
 				windowFlag = 1;	//金魚すくいスタート
+
+				for (unsigned int i = 0; i < kingyo_num; i++) {
+					/* 金魚グループに関する初期化 */
+					kingyo_group[i].setSpeed(1.0, 3.0); // 金魚のスピードを設定
+					kingyo_group[i].setDifficulty(1);
+					kingyo_group[i].animsp = 30; // アニメーションの設定
+					kingyo_group[i].spawn_position(dice(mt) % 980 + 100, dice(mt) % 400 + 100);//範囲内に収まるように補正
+					if (i % 2 == 0) kingyo_group[i].SetMovement(MOV_OPTION::CIRCLE, 300, 1.0);
+					if (i % 3 == 0)kingyo_group[i].SetMovement(MOV_OPTION::WAVE, 100, 100);
+				}
+				for (unsigned int i = 0; i < telescope_num; i++) {
+					/* 出目金グループに関する初期化 */
+					telescope_group[i].setSpeed(1.0, 3.0); // 出目金のスピードを設定
+					telescope_group[i].setDifficulty(1);
+					telescope_group[i].animsp = 30; // アニメーションの設定
+					if (i % 2 == 0) telescope_group[i].SetMovement(MOV_OPTION::CIRCLE, 300, 1.0);
+					if (i % 3 == 0) telescope_group[i].SetMovement(MOV_OPTION::WAVE, 100, 100);
+				}
+				for (unsigned char i = 0; i < poi_num_remaining; ++i)
+				{
+					/* 残りポイ数表示用オブジェクトグループ */
+					remaining_poi[i].x -= 40 * i; // ポイの位置をずらす
+				}
+
 				timer60sec.reset();
 				cought_kingyo = 0;
 				cought_telescope = 0;
@@ -108,31 +125,63 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 			poi.draw();
 			kingyo_group.draw();
 			telescope_group.draw();
+			for (unsigned char i = 0; i < poi_num_remaining; ++i)remaining_poi[i].draw();
 
 			/* 次状態の管理 */
-			if (timer60sec() == 0) windowFlag = 2; // 60秒たったら終了しスコア表示へ
+			if (timer60sec() == 0 || poi_num_remaining == 0) windowFlag = 2; // 60秒たったら終了しスコア表示へ
 			else DrawFormatStringToHandle(520, 60, GetColor(120, 120, 120), count_Font, "のこり%d秒", timer60sec() / 60); // 残り時間表示
 			if (z_push.GetKeyDown(KEY_INPUT_Z)) {
 				/* zキーが押された */
-				std::vector<int> index_management;
-				for (int i = 0; i < (int)kingyo_num; i++) {
+				poi_destroy = true;
+				for (int i = 0; i < (int)kingyo_group.size(); i++) {
 					if (kingyo_group[i].isCought(poi, mt, dice)) {
-						index_management.push_back(i);
+						switch (rand_four(mt))
+						{
+						case 0:
+							kingyo_group[i].spawn_position(1080, rand_posy(mt));
+							break;
+						case 1:
+							kingyo_group[i].spawn_position(101, rand_posy(mt));
+							break;
+						case 2:
+							kingyo_group[i].spawn_position(rand_posx(mt), 500);
+							break;
+						case 3:
+							kingyo_group[i].spawn_position(rand_posx(mt), 101);
+							break;
+						default:
+							break;
+						}
+						cought_kingyo++;
+						poi_destroy = false;
 					}
 				}
-				for (int i = (int)index_management.size() - 1; i >= 0; i--) {
-					kingyo_group[index_management[i]].spawn_position(1080, dice(mt) % 400 + 100); //捕獲されたら、削除する代わりに、端っこから再登場
-					cought_kingyo++;
-				}
-				index_management.resize(0);
-				for (int i = 0; i < (int)telescope_num; i++) {
+				for (int i = 0; i < (int)telescope_group.size(); i++) {
 					if (telescope_group[i].isCought(poi, mt, dice)) {
-						index_management.push_back(i);
+						switch (rand_four(mt))
+						{
+						case 0:
+							telescope_group[i].spawn_position(1080, rand_posy(mt));
+							break;
+						case 1:
+							telescope_group[i].spawn_position(101, rand_posy(mt));
+							break;
+						case 2:
+							telescope_group[i].spawn_position(rand_posx(mt), 500);
+							break;
+						case 3:
+							telescope_group[i].spawn_position(rand_posx(mt), 101);
+							break;
+						default:
+							break;
+						}
+						cought_telescope++;
+						poi_destroy = false;
 					}
 				}
-				for (int i = (int)index_management.size() - 1; i >= 0; i--) {
-					telescope_group[index_management[i]].spawn_position(150, dice(mt) % 400 + 100); //縦で線形移動だとポイの移動制限で取れないので若干余白あり
-					cought_telescope++;
+				if (poi_destroy)
+				{
+					poi_num_remaining--;
 				}
 			}
 			poi.point_change();


### PR DESCRIPTION
# 実装の概要
* ポイの枚数制限
* 金魚の再発生位置をもっとランダムにした
* `Aim` クラスの描画倍率を変える機能を `Obj` クラスに移した
* 金魚に関する初期化のタイミングをスタートを押した直後に変更した
# 見てほしいところ
* ポイの残り枚数が見やすいか
# 既知のバグ
* 金魚の初期位置が偏っている