### PR TITLE
再帰の問題を修正

### DIFF
--- a/kingyomain.cpp
+++ b/kingyomain.cpp
@@ -1,7 +1,7 @@
 ﻿#include "main.h"
 #include "stdafx.h"
 
-void kingyomain(int font, int bgm, int effect, int calling_check) {
+int kingyomain(int font, int bgm, int effect, int calling_check) {
 	/* ゲームの基本データ */
 	int windowFlag = 0; // 現在のウィンドウを管理するフラグ
 	int FramePerSecond = 60; //fps
@@ -250,14 +250,11 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 			/* 次状態の管理 */
 			if (button_back.isReleasedLeft(click_event, button_type, cx, cy, log_type)) {
 				PlaySoundMem(effect, DX_PLAYTYPE_BACK);
-				windowFlag = 0; // スタート画面へ戻る
+				return 0; // タイトル画面へ
 			}
 			if (timer80sec() == 0) { // スコア表示時間を過ぎたら
-				windowFlag = 0; // タイトル画面へ
-				timer60sec.reset(); // タイマーのリセット
-				timer80sec.reset();
-				count_play++; // プレイ回数を増やす
 				PlaySoundMem(effect, DX_PLAYTYPE_BACK); // 効果音
+				return 0; // タイトル画面へ
 			}
 			button_back.next(px, py);
 			timer80sec.update(); // タイマーの更新
@@ -274,10 +271,10 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 			}
 		}
 		else if (windowFlag == 10) {	//射的ゲームへ
-			syatekimain(font, bgm, effect, calling_check);
+			return 1;
 		}
 		else {
-			return;
+			return 0;
 		}
 		ScreenFlip();
 
@@ -289,4 +286,5 @@ void kingyomain(int font, int bgm, int effect, int calling_check) {
 		}
 		prevtime = nowtime;
 	}
+	return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -37,8 +37,13 @@ int WINAPI WinMain([[maybe_unused]] _In_ HINSTANCE hInstance, [[maybe_unused]] _
         exit(1);
     }
     int calling_check = 0;
+    int flag = 1; // どちらのゲームを呼び出すか管理するフラグ(0: 金魚, 1: 射的)
     //bgmを読み込む
-    syatekimain(FontHandle, bgm, effect,calling_check);
+
+    while (1) {
+        if (flag == 0) flag = kingyomain(FontHandle, bgm, effect, calling_check);
+        else flag = syatekimain(FontHandle, bgm, effect,calling_check);
+    }
     //終わり
     DxLib_End();
     return 0;

--- a/main.h
+++ b/main.h
@@ -10,6 +10,6 @@
 #include "csvManager.h"
 #include "gun.h"
 
-void kingyomain(int font, int bgm, int effect, int calling_check);
+int kingyomain(int font, int bgm, int effect, int calling_check);
 void game_temp();
-void syatekimain(int font, int bgm, int effect, int calling_check);
+int syatekimain(int font, int bgm, int effect, int calling_check);

--- a/syatekimain.cpp
+++ b/syatekimain.cpp
@@ -2,7 +2,7 @@
 #include "stdafx.h"
 
 
-void syatekimain(int font, int bgm, int effect, int calling_check) {
+int syatekimain(int font, int bgm, int effect, int calling_check) {
 	int windowFlag = 0;  // 現在のウィンドウを管理するフラグ
 	int FramePerSecond = 60;//fps
 	int score = 0;	//ゲームのスコア
@@ -96,7 +96,7 @@ void syatekimain(int font, int bgm, int effect, int calling_check) {
 				windowFlag = 2;	//結果表示
 			}
 			if (button_gotokingyo.isReleasedLeft(click_event, button_type, cx, cy, log_type)) {
-				windowFlag = 10;	//金魚すくいゲームへ遷移
+				return 0; //金魚すくいゲームへ遷移
 			}
 		}
 		else if (windowFlag == 1) { // ゲーム中のウィンドウ
@@ -165,10 +165,10 @@ void syatekimain(int font, int bgm, int effect, int calling_check) {
 		}
 		else if (windowFlag == 10) {  // ゲームの終了
 			calling_check = 1;
-			kingyomain(font, bgm, effect, calling_check);
+			return 1;
 		}
 		else {
-			return;
+			return 1;
 		}
 		ScreenFlip();
 
@@ -180,4 +180,5 @@ void syatekimain(int font, int bgm, int effect, int calling_check) {
 		}
 		prevtime = nowtime;
 	}
+	return 1;
 }


### PR DESCRIPTION
# 実装の概要
* ゲームを切り替える時に再帰し続づける実装を、main.cppに位置ゲームごとにreturnすることで解決しました
# 変更点
* `kingyomain.cpp`, `syatekimain.cpp`の返り値をvoidからintに変更しました
* main.cppに無限ループを用意し、直前の関数の返却値によって次に呼び出すゲームを決定するようにしました
# 見てほしいところ
* 正常に動作するか
* 結果の保存等ランキングシステムに影響があるか
# 既知のバグ
* 特になし